### PR TITLE
Adds support for generating queries on references

### DIFF
--- a/example/yoyo/repositories/query/person/query.go
+++ b/example/yoyo/repositories/query/person/query.go
@@ -62,6 +62,48 @@ func (q Query) AgeNot(in float64) Query {
 	}}
 }
 
+func (q Query) CityId(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityId(in).n},
+		Operator: query.And,
+	}}
+}
+
+func (q Query) CityIdGreaterOrEqual(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityIdGreaterOrEqual(in).n},
+		Operator: query.And,
+	}}
+}
+
+func (q Query) CityIdGreaterThan(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityIdGreaterThan(in).n},
+		Operator: query.And,
+	}}
+}
+
+func (q Query) CityIdLessOrEqual(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityIdLessOrEqual(in).n},
+		Operator: query.And,
+	}}
+}
+
+func (q Query) CityIdLessThan(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityIdLessThan(in).n},
+		Operator: query.And,
+	}}
+}
+
+func (q Query) CityIdNot(in int32) Query {
+	return Query{query.Node{
+		Children: &[2]query.Node{q.n, CityIdNot(in).n},
+		Operator: query.And,
+	}}
+}
+
 func (q Query) FavoriteColor(in string) Query {
 	return Query{query.Node{
 		Children: &[2]query.Node{q.n, FavoriteColor(in).n},
@@ -269,6 +311,66 @@ func AgeNot(in float64) Query {
 	return Query{query.Node{
 		Condition: query.Condition{
 			Column:   "age",
+			Operator: query.NotEquals,
+			Value:    in,
+		},
+	}}
+}
+
+func CityId(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
+			Operator: query.Equals,
+			Value:    in,
+		},
+	}}
+}
+
+func CityIdGreaterOrEqual(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
+			Operator: query.GreaterOrEqual,
+			Value:    in,
+		},
+	}}
+}
+
+func CityIdGreaterThan(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
+			Operator: query.GreaterThan,
+			Value:    in,
+		},
+	}}
+}
+
+func CityIdLessOrEqual(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
+			Operator: query.LessOrEqual,
+			Value:    in,
+		},
+	}}
+}
+
+func CityIdLessThan(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
+			Operator: query.LessThan,
+			Value:    in,
+		},
+	}}
+}
+
+func CityIdNot(in int32) Query {
+	return Query{query.Node{
+		Condition: query.Condition{
+			Column:   "fk_city_id",
 			Operator: query.NotEquals,
 			Value:    in,
 		},

--- a/internal/repository/generate.go
+++ b/internal/repository/generate.go
@@ -160,7 +160,7 @@ func InitGeneratorLoader(
 		return newGenerator(
 			NewEntityGenerator(packageName, config.Schema),
 			NewEntityRepositoryGenerator(packageName, adapter, reposPath, findPackagePath),
-			NewQueryFileGenerator(reposPath, findPackagePath),
+			NewQueryFileGenerator(reposPath, findPackagePath, config.Schema),
 			NewRepositoriesGenerator(packageName, reposPath, findPackagePath, config.Schema),
 			NewQueryNodeGenerator(),
 			file.CreateWithDirs,

--- a/internal/repository/generate_query.go
+++ b/internal/repository/generate_query.go
@@ -10,11 +10,35 @@ import (
 	"github.com/yoyo-project/yoyo/internal/schema"
 )
 
-func NewQueryFileGenerator(reposPath string, findPackagePath Finder) EntityGenerator {
+func NewQueryFileGenerator(reposPath string, findPackagePath Finder, db schema.Database) EntityGenerator {
 	return func(t schema.Table, w io.StringWriter) error {
 		var methods, functions, imports []string
 		for _, c := range t.Columns {
 			ms, fs, is := template.GenerateQueryLogic(c.Name, c)
+			methods = append(methods, ms...)
+			functions = append(functions, fs...)
+			imports = append(imports, is...)
+		}
+
+		for _, r := range t.References {
+			if r.HasMany {
+				continue // Skip HasMany references which require a join
+			}
+
+			ft, ok := db.GetTable(r.TableName)
+			if !ok {
+				return fmt.Errorf("unable to generate queries for table %s, missing foreign table %s", t.Name, r.TableName)
+			}
+
+			var ms, fs, is []string
+
+			for i, n := range r.ColNames(ft) {
+				c := ft.PKColumns()[i]
+				// Override the GoName in order to generate correct method/function names
+				c.GoName = ft.ExportedGoName() + c.ExportedGoName()
+				ms, fs, is = template.GenerateQueryLogic(n, c)
+			}
+
 			methods = append(methods, ms...)
 			functions = append(functions, fs...)
 			imports = append(imports, is...)

--- a/internal/schema/schema_reference.go
+++ b/internal/schema/schema_reference.go
@@ -9,7 +9,7 @@ const (
 )
 
 // ColNames returns a list foreign key column names for the given reference. The method assumes that the `fTable` value
-//is correct (for example, the "many" side in a one-to-many reference) and not necessarily the target table of the
+// is correct (for example, the "many" side in a one-to-many reference) and not necessarily the target table of the
 // Reference itself. So make sure the Yoyo-to-RDB reference translation has already happened before calling ColNames.
 func (r *Reference) ColNames(ft Table) []string {
 	var (


### PR DESCRIPTION
Previously, query generation only worked on explicit defined columns. This
change adds query generation for references.

Only generates queries that have generated columns on the table in
question (no joins)